### PR TITLE
docs: add schema metadata

### DIFF
--- a/assistants/views.py
+++ b/assistants/views.py
@@ -1,18 +1,21 @@
-from rest_framework.views import APIView
+from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
-from rest_framework import status, permissions
+from rest_framework import permissions
 from django.shortcuts import get_object_or_404
+from drf_spectacular.utils import extend_schema
 from accounts.models import StaffRole
 from .services import process_va_chat
 from .serializers import AssistantChatSerializer, AssistantResponseSerializer
 
 
-class AssistantChatView(APIView):
+class AssistantChatView(GenericAPIView):
     permission_classes = [permissions.IsAuthenticated]
+    serializer_class = AssistantChatSerializer
 
+    @extend_schema(responses=AssistantResponseSerializer)
     def post(self, request, assistant_id):
         assistant = get_object_or_404(StaffRole, pk=assistant_id, is_virtual=True)
-        serializer = AssistantChatSerializer(data=request.data)
+        serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         user_input = serializer.validated_data["message"]
 
@@ -20,7 +23,7 @@ class AssistantChatView(APIView):
 
         response_data = AssistantResponseSerializer({
             "assistant": assistant.title,
-            "response": response
+            "response": response,
         }).data
 
         return Response(response_data)

--- a/users/views.py
+++ b/users/views.py
@@ -4,6 +4,7 @@ from rest_framework.response import Response
 from rest_framework.permissions import AllowAny
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework.views import APIView
+from drf_spectacular.utils import extend_schema, OpenApiParameter, OpenApiResponse
 
 from users.serializers import RegisterSerializer, LoginSerializer, PasswordResetRequestSerializer, PasswordResetConfirmSerializer
 from users.tokens import account_activation_token, decode_uid
@@ -41,6 +42,18 @@ class LoginView(generics.GenericAPIView):
 
 
 class VerifyEmailView(APIView):
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(name="uid", type=str, location=OpenApiParameter.QUERY),
+            OpenApiParameter(name="token", type=str, location=OpenApiParameter.QUERY),
+        ],
+        responses={
+            200: OpenApiResponse(description="Email verified successfully"),
+            400: OpenApiResponse(description="Invalid link or token"),
+            404: OpenApiResponse(description="Invalid user"),
+        },
+    )
     def get(self, request):
         uid = decode_uid(request.GET.get('uid'))
         token = request.GET.get('token')


### PR DESCRIPTION
## Summary
- replace AssistantChatView's APIView with GenericAPIView and document response schema
- document verify email query params and responses with `extend_schema`

## Testing
- `pytest` *(fails: No module named 'tamiti_studio.settings.dev')*
- `DJANGO_SETTINGS_MODULE=tamiti_studio.settings pytest` *(fails: No module named 'debug_toolbar')*
- `pip install django-debug-toolbar` *(fails: Could not find a version that satisfies the requirement due to proxy errors)*

------
https://chatgpt.com/codex/tasks/task_e_688faee8a68c83219eb2742c78b49737