### PR TITLE
Handle OpenAI errors with logging

### DIFF
--- a/assistants/services.py
+++ b/assistants/services.py
@@ -1,6 +1,11 @@
+import logging
 import openai
+from openai.error import OpenAIError
 from django.conf import settings
 from .models import VACommand, AssistantLog, DefaultResponse
+
+
+logger = logging.getLogger(__name__)
 
 
 def resolve_va_command(assistant, user_input, user=None):
@@ -35,7 +40,8 @@ def generate_gpt_response(assistant, user_input):
             temperature=0.7,
         )
         return response.choices[0].message.content
-    except Exception:
+    except OpenAIError as exc:
+        logger.exception("OpenAI request failed", exc_info=exc)
         return get_default_response(assistant)
 
 


### PR DESCRIPTION
## Summary
- handle OpenAI API failures explicitly instead of catching all exceptions
- log OpenAI errors before returning assistant default response

## Testing
- `pytest` *(fails: No module named 'debug_toolbar')*

------
https://chatgpt.com/codex/tasks/task_e_688fb82247d083219844d00c744c8964