### PR TITLE
Add global pagination, API versioning, and unified error handler

### DIFF
--- a/common/exceptions.py
+++ b/common/exceptions.py
@@ -1,0 +1,19 @@
+"""Common exception handlers for the project."""
+
+from rest_framework.views import exception_handler
+from rest_framework.response import Response
+from rest_framework import status
+
+
+def custom_exception_handler(exc, context):
+    """Return a consistent error response structure."""
+    response = exception_handler(exc, context)
+
+    if response is None:
+        # If DRF couldn't handle the exception, fall back to a generic 500.
+        return Response(
+            {"errors": [str(exc)]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+        )
+
+    return Response({"errors": response.data}, status=response.status_code)
+

--- a/tamiti_studio/settings.py
+++ b/tamiti_studio/settings.py
@@ -152,9 +152,11 @@ REST_FRAMEWORK = {
         'rest_framework_simplejwt.authentication.JWTAuthentication',
     ],
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
-    # 'DEFAULT_PAGINATION_CLASS': 'common.pagination.DefaultPagination',
-    # 'PAGE_SIZE': 10,
-    # 'DEFAULT_FILTER_BACKENDS': ['django_filters.rest_framework.DjangoFilterBackend'],
+    'DEFAULT_PAGINATION_CLASS': 'common.pagination.DefaultPagination',
+    'PAGE_SIZE': 10,
+    'DEFAULT_FILTER_BACKENDS': ['django_filters.rest_framework.DjangoFilterBackend'],
+    'EXCEPTION_HANDLER': 'common.exceptions.custom_exception_handler',
+    'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.NamespaceVersioning',
 }
 
 
@@ -174,11 +176,6 @@ SIMPLE_JWT = {
     'ACCESS_TOKEN_LIFETIME': timedelta(minutes=15),
     'REFRESH_TOKEN_LIFETIME': timedelta(days=1),
     'AUTH_HEADER_TYPES': ('Bearer',),
-
-    'DEFAULT_PAGINATION_CLASS': 'common.pagination.DefaultPagination',
-    'PAGE_SIZE': 10,
-    'DEFAULT_FILTER_BACKENDS': ['django_filters.rest_framework.DjangoFilterBackend'],
-
 }
 
 # Security

--- a/tamiti_studio/urls.py
+++ b/tamiti_studio/urls.py
@@ -1,22 +1,8 @@
-"""
-URL configuration for tamiti_studio project.
+"""URL configuration for tamiti_studio project."""
 
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/5.1/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  path('', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.urls import include, path
-    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
-"""
-from django.contrib import admin
-from django.urls import path, include
 from django.conf import settings
+from django.contrib import admin
+from django.urls import include, path
 
 from drf_spectacular.views import (
     SpectacularAPIView,
@@ -24,30 +10,38 @@ from drf_spectacular.views import (
     SpectacularSwaggerView,
 )
 
+
+# Group all API endpoints under a versioned namespace
+api_v1_patterns = [
+    path('auth/', include('users.urls')),
+    path('chat/', include('chatrooms.urls')),
+    path('tasks/', include('tasks.urls')),
+    path('users/', include('users.urls')),
+    path('field/', include('field.urls')),
+    path('projects/', include('projects.urls')),
+    path('finance/', include('finance.urls')),
+    path('assistants/', include('assistants.urls')),
+    path('accounts/', include('accounts.urls')),
+    path('social/', include('social.urls')),
+    path('content/', include('content.urls')),
+]
+
+
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('api/auth/', include('users.urls')),
-    path('api/chat/', include('chatrooms.urls')),
-    path('api/tasks/', include('tasks.urls')),
-    path('api/users/', include('users.urls')),
-    path('api/field/', include('field.urls')),
-    path('api/projects/', include('projects.urls')),
-    path('api/finance/', include('finance.urls')),
-    path('api/assistants/', include('assistants.urls')),
-    path('api/accounts/', include('accounts.urls')),
-    path('api/social/', include('social.urls')),
-    path('api/content/', include('content.urls')),
+    path('api/v1/', include((api_v1_patterns, 'v1'), namespace='v1')),
 
-    # swagger endpoints
+    # Swagger / OpenAPI endpoints
     path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
     path('api/docs/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
     path('api/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
-
 ]
 
-# debug too settings
+
 if settings.DEBUG:
     import debug_toolbar
+
     urlpatterns += [
-        path("__debug__/", include(debug_toolbar.urls)),
+        path('__debug__/', include(debug_toolbar.urls)),
     ]
+


### PR DESCRIPTION
## Summary
- enable global DRF pagination, filtering, and versioning
- group routers under `/api/v1` and add unified exception handling

## Testing
- `pytest` *(fails: No module named 'debug_toolbar')*

------
https://chatgpt.com/codex/tasks/task_e_688fb9623d6083219b35bf69e4d56dda