### PR TITLE
Scope debug toolbar to dev settings

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -25,7 +25,6 @@ INSTALLED_APPS = [
     'taggit',
     'django_filters',
     'drf_spectacular',
-    'debug_toolbar',
 
     'core',
     'users',
@@ -43,7 +42,6 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
-    "debug_toolbar.middleware.DebugToolbarMiddleware",
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -3,6 +3,8 @@ from .base import *
 DEBUG = True
 ALLOWED_HOSTS = []
 
+INSTALLED_APPS += ['debug_toolbar']
+MIDDLEWARE.insert(1, 'debug_toolbar.middleware.DebugToolbarMiddleware')
 
 INTERNAL_IPS = ["127.0.0.1"]
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'


### PR DESCRIPTION
## Summary
- restrict django-debug-toolbar to development settings

## Testing
- `pytest` (known failures)


------
https://chatgpt.com/codex/tasks/task_e_688fc8c521748321a82fbc69c75aa4eb