### PR TITLE
Use environment variables for key, database, hosts, and email

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -2,13 +2,17 @@ import os
 from datetime import timedelta
 from pathlib import Path
 
+from decouple import Csv, config
+
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
-SECRET_KEY = 'django-insecure-05ek+7)&s6q)25x_!^k%ma(inzummqjjzwt-bng=nm@t_czv+@'
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = config("SECRET_KEY")
 
 DEBUG = False
 
-ALLOWED_HOSTS: list[str] = []
+# Hosts/domain names that are valid for this site
+ALLOWED_HOSTS: list[str] = config("ALLOWED_HOSTS", default="", cast=Csv())
 
 INSTALLED_APPS = [
     'django.contrib.admin',
@@ -88,9 +92,13 @@ LOGGING = {
 WSGI_APPLICATION = 'tamiti_studio.wsgi.application'
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+    "default": {
+        "ENGINE": config("DB_ENGINE", default="django.db.backends.sqlite3"),
+        "NAME": config("DB_NAME", default=str(BASE_DIR / "db.sqlite3")),
+        "USER": config("DB_USER", default=""),
+        "PASSWORD": config("DB_PASSWORD", default=""),
+        "HOST": config("DB_HOST", default=""),
+        "PORT": config("DB_PORT", default=""),
     }
 }
 
@@ -110,7 +118,16 @@ AUTH_PASSWORD_VALIDATORS = [
 ]
 
 AUTH_USER_MODEL = 'users.User'
-DEFAULT_FROM_EMAIL = 'hello@tamiti.com'
+
+EMAIL_BACKEND = config(
+    "EMAIL_BACKEND", default="django.core.mail.backends.smtp.EmailBackend"
+)
+EMAIL_HOST = config("EMAIL_HOST", default="")
+EMAIL_PORT = config("EMAIL_PORT", default=587, cast=int)
+EMAIL_USE_TLS = config("EMAIL_USE_TLS", default=True, cast=bool)
+EMAIL_HOST_USER = config("EMAIL_HOST_USER", default="")
+EMAIL_HOST_PASSWORD = config("EMAIL_HOST_PASSWORD", default="")
+DEFAULT_FROM_EMAIL = config("DEFAULT_FROM_EMAIL", default="hello@tamiti.com")
 
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -1,7 +1,6 @@
 from .base import *
 
 DEBUG = True
-ALLOWED_HOSTS = []
 
 
 INTERNAL_IPS = ["127.0.0.1"]

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -1,6 +1,3 @@
 from .base import *
 
 DEBUG = False
-ALLOWED_HOSTS = ['*']
-
-EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'

--- a/documentation/env_variables.md
+++ b/documentation/env_variables.md
@@ -1,0 +1,23 @@
+# Environment Variables
+
+The application relies on the following environment variables. Create a `.env` file or set them in your environment before running the project.
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `SECRET_KEY` | **Required.** Django secret key. | none |
+| `ALLOWED_HOSTS` | Comma-separated list of hostnames served by Django. | empty |
+| `DB_ENGINE` | Django database engine. | `django.db.backends.sqlite3` |
+| `DB_NAME` | Database name or path. | `db.sqlite3` in project root |
+| `DB_USER` | Database user. | empty |
+| `DB_PASSWORD` | Database password. | empty |
+| `DB_HOST` | Database host. | empty |
+| `DB_PORT` | Database port. | empty |
+| `EMAIL_BACKEND` | Django email backend. | `django.core.mail.backends.smtp.EmailBackend` |
+| `EMAIL_HOST` | Email server host. | empty |
+| `EMAIL_PORT` | Email server port. | `587` |
+| `EMAIL_USE_TLS` | Whether to use TLS for email. (`True`/`False`) | `True` |
+| `EMAIL_HOST_USER` | Email server username. | empty |
+| `EMAIL_HOST_PASSWORD` | Email server password. | empty |
+| `DEFAULT_FROM_EMAIL` | Default address used for outgoing email. | `hello@tamiti.com` |
+
+These settings allow the application to be configured for different environments without modifying the source code.


### PR DESCRIPTION
## Summary
- Load SECRET_KEY and ALLOWED_HOSTS from environment variables using `python-decouple`
- Configure database and email settings via environment variables
- Document required environment variables

## Testing
- `SECRET_KEY=test pytest` *(fails: 5 failed, 19 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688fc8bc04e08321b8b3a6ebf2b7f5ce