### PR TITLE
refactor: move REST settings to proper section

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -117,6 +117,9 @@ REST_FRAMEWORK = {
         'rest_framework_simplejwt.authentication.JWTAuthentication',
     ],
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+    'DEFAULT_PAGINATION_CLASS': 'common.pagination.DefaultPagination',
+    'PAGE_SIZE': 10,
+    'DEFAULT_FILTER_BACKENDS': ['django_filters.rest_framework.DjangoFilterBackend'],
 }
 
 SPECTACULAR_SETTINGS = {
@@ -135,10 +138,6 @@ SIMPLE_JWT = {
     'ACCESS_TOKEN_LIFETIME': timedelta(minutes=15),
     'REFRESH_TOKEN_LIFETIME': timedelta(days=1),
     'AUTH_HEADER_TYPES': ('Bearer',),
-
-    'DEFAULT_PAGINATION_CLASS': 'common.pagination.DefaultPagination',
-    'PAGE_SIZE': 10,
-    'DEFAULT_FILTER_BACKENDS': ['django_filters.rest_framework.DjangoFilterBackend'],
 }
 
 # Security


### PR DESCRIPTION
## Summary
- relocate pagination and filter settings from SIMPLE_JWT to REST_FRAMEWORK
- keep SIMPLE_JWT focused on JWT-only options

## Testing
- `pytest` *(fails: Module...' bank_account ... etc)*

------
https://chatgpt.com/codex/tasks/task_e_688fc8b054d88321a9bc9426b919a7d3