### PR TITLE
Add explicit dependencies and tags fields to task serializers

### DIFF
--- a/tasks/serializers.py
+++ b/tasks/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from tasks.models import Task, TaskGroup
+from taggit.serializers import TaggitSerializer, TagListSerializerField
 
 
 class TaskGroupSerializer(serializers.ModelSerializer):
@@ -19,7 +20,12 @@ class TaskSerializer(serializers.ModelSerializer):
         read_only_fields = ('created_at', 'updated_at', 'completed_at')
 
 
-class TaskCreateSerializer(serializers.ModelSerializer):
+class TaskCreateSerializer(TaggitSerializer, serializers.ModelSerializer):
+    dependencies = serializers.PrimaryKeyRelatedField(
+        many=True, queryset=Task.objects.all(), required=False
+    )
+    tags = TagListSerializerField(required=False)
+
     class Meta:
         model = Task
         fields = (
@@ -29,11 +35,16 @@ class TaskCreateSerializer(serializers.ModelSerializer):
         )
 
 
-class TaskUpdateSerializer(serializers.ModelSerializer):
+class TaskUpdateSerializer(TaggitSerializer, serializers.ModelSerializer):
+    dependencies = serializers.PrimaryKeyRelatedField(
+        many=True, queryset=Task.objects.all(), required=False
+    )
+    tags = TagListSerializerField(required=False)
+
     class Meta:
         model = Task
         fields = (
             'title', 'description', 'priority', 'is_completed', 'due_date',
             'estimated_hours', 'actual_hours', 'assigned_to',
-         'tags', 'notes', 'milestone', 'dependencies'
+            'tags', 'notes', 'milestone', 'dependencies'
         )


### PR DESCRIPTION
## Summary
- add Taggit dependency tags and dependencies fields to task create and update serializers

## Testing
- `pytest` *(fails: TypeError: DirectThread() got unexpected keyword arguments: 'user1', AttributeError: Unknown formatter 'bank_account', assert 404 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_688fc89af96883218fa15ef40cffdb91