### PR TITLE
Use serializers for dashboard metrics

### DIFF
--- a/dashboard/serializers.py
+++ b/dashboard/serializers.py
@@ -1,0 +1,67 @@
+from rest_framework import serializers
+
+
+class ProjectSummarySerializer(serializers.Serializer):
+    """Serializer for project summary statistics."""
+
+    total = serializers.IntegerField()
+    active = serializers.IntegerField()
+    completed = serializers.IntegerField()
+
+
+class TaskSummarySerializer(serializers.Serializer):
+    """Serializer for task summary statistics."""
+
+    total = serializers.IntegerField()
+    completed = serializers.IntegerField()
+    overdue = serializers.IntegerField()
+
+
+class FinanceSummarySerializer(serializers.Serializer):
+    """Serializer for aggregated financial information."""
+
+    income = serializers.DecimalField(max_digits=12, decimal_places=2)
+    expenses = serializers.DecimalField(max_digits=12, decimal_places=2)
+    goals_count = serializers.IntegerField()
+
+
+class RecentVisitSerializer(serializers.Serializer):
+    """Serializer for recent field visits."""
+
+    location = serializers.CharField()
+    rep__email = serializers.EmailField()
+    date_time = serializers.DateTimeField()
+
+
+class FieldSummarySerializer(serializers.Serializer):
+    """Serializer for field module statistics."""
+
+    total_visits = serializers.IntegerField()
+    recent = RecentVisitSerializer(many=True)
+
+
+class LeadsSummarySerializer(serializers.Serializer):
+    """Serializer for lead statistics."""
+
+    total = serializers.IntegerField()
+    won = serializers.IntegerField()
+    lost = serializers.IntegerField()
+
+
+class SocialSummarySerializer(serializers.Serializer):
+    """Serializer for social media post statistics."""
+
+    draft = serializers.IntegerField()
+    published = serializers.IntegerField()
+    platforms = serializers.ListField(child=serializers.CharField())
+
+
+class DashboardKPISerializer(serializers.Serializer):
+    """Serializer aggregating KPI metrics from all modules."""
+
+    projects = ProjectSummarySerializer()
+    tasks = TaskSummarySerializer()
+    finance = FinanceSummarySerializer()
+    field = FieldSummarySerializer()
+    leads = LeadsSummarySerializer()
+    social = SocialSummarySerializer()

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -1,9 +1,19 @@
 """API endpoints for dashboard metrics."""
 
+from drf_spectacular.utils import extend_schema
+from rest_framework import generics
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from rest_framework.views import APIView
 
+from .serializers import (
+    DashboardKPISerializer,
+    FieldSummarySerializer,
+    FinanceSummarySerializer,
+    LeadsSummarySerializer,
+    ProjectSummarySerializer,
+    SocialSummarySerializer,
+    TaskSummarySerializer,
+)
 from .services import (
     get_cached_dashboard_metrics,
     get_field_summary,
@@ -15,54 +25,74 @@ from .services import (
 )
 
 
-class ProjectSummaryView(APIView):
+class ProjectSummaryView(generics.GenericAPIView):
     permission_classes = [IsAuthenticated]
+    serializer_class = ProjectSummarySerializer
 
+    @extend_schema(responses=ProjectSummarySerializer)
     def get(self, request):
-        return Response(get_project_summary(request.user))
+        serializer = self.get_serializer(get_project_summary(request.user))
+        return Response(serializer.data)
 
 
-class TaskSummaryView(APIView):
+class TaskSummaryView(generics.GenericAPIView):
     permission_classes = [IsAuthenticated]
+    serializer_class = TaskSummarySerializer
 
+    @extend_schema(responses=TaskSummarySerializer)
     def get(self, request):
-        return Response(get_task_summary(request.user))
+        serializer = self.get_serializer(get_task_summary(request.user))
+        return Response(serializer.data)
 
 
-class FinanceSummaryView(APIView):
+class FinanceSummaryView(generics.GenericAPIView):
     permission_classes = [IsAuthenticated]
+    serializer_class = FinanceSummarySerializer
 
+    @extend_schema(responses=FinanceSummarySerializer)
     def get(self, request):
-        return Response(get_finance_summary(request.user))
+        serializer = self.get_serializer(get_finance_summary(request.user))
+        return Response(serializer.data)
 
 
-class FieldSummaryView(APIView):
+class FieldSummaryView(generics.GenericAPIView):
     permission_classes = [IsAuthenticated]
+    serializer_class = FieldSummarySerializer
 
+    @extend_schema(responses=FieldSummarySerializer)
     def get(self, request):
-        return Response(get_field_summary(request.user))
+        serializer = self.get_serializer(get_field_summary(request.user))
+        return Response(serializer.data)
 
 
-class LeadsSummaryView(APIView):
+class LeadsSummaryView(generics.GenericAPIView):
     permission_classes = [IsAuthenticated]
+    serializer_class = LeadsSummarySerializer
 
+    @extend_schema(responses=LeadsSummarySerializer)
     def get(self, request):
-        return Response(get_leads_summary(request.user))
+        serializer = self.get_serializer(get_leads_summary(request.user))
+        return Response(serializer.data)
 
 
-class SocialSummaryView(APIView):
+class SocialSummaryView(generics.GenericAPIView):
     permission_classes = [IsAuthenticated]
+    serializer_class = SocialSummarySerializer
 
+    @extend_schema(responses=SocialSummarySerializer)
     def get(self, request):
-        return Response(get_social_summary(request.user))
+        serializer = self.get_serializer(get_social_summary(request.user))
+        return Response(serializer.data)
 
 
-class DashboardKPIView(APIView):
+class DashboardKPIView(generics.GenericAPIView):
     """Return consolidated KPIs for the authenticated user."""
 
     permission_classes = [IsAuthenticated]
+    serializer_class = DashboardKPISerializer
 
+    @extend_schema(responses=DashboardKPISerializer)
     def get(self, request):
         data = get_cached_dashboard_metrics(request.user)
-        return Response(data)
-
+        serializer = self.get_serializer(data)
+        return Response(serializer.data)


### PR DESCRIPTION
## Summary
- add serializers for project, task, finance, field, lead, social, and aggregated dashboard metrics
- convert dashboard metric views to `GenericAPIView` with schema annotations

## Testing
- `pytest tests/test_chat.py::test_direct_message_exchange -q` (fails: `DirectThread() got unexpected keyword arguments`)
- `pytest tests/test_dashboard.py::test_dashboard_kpis_endpoint_returns_metrics -q`


------
https://chatgpt.com/codex/tasks/task_e_688fc87c91dc8321aa34ec55e35f2fa0