### PR TITLE
Handle swagger view querysets

### DIFF
--- a/projects/views.py
+++ b/projects/views.py
@@ -20,6 +20,8 @@ class ProjectListCreateView(generics.ListCreateAPIView):
         return ProjectSummarySerializer if self.request.method == 'GET' else ProjectSerializer
 
     def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return Project.objects.none()
         qs = Project.objects.filter(created_by=self.request.user)
         if status := self.request.query_params.get('status'):
             qs = qs.filter(status=status)

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -21,6 +21,8 @@ class TaskListCreateView(generics.ListCreateAPIView):
         return TaskCreateSerializer if self.request.method == 'POST' else TaskSerializer
 
     def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return Task.objects.none()
         qs = Task.objects.filter(project__created_by=self.request.user)
         if pid := self.request.query_params.get('project'):
             qs = qs.filter(project_id=pid)


### PR DESCRIPTION
## Summary
- Avoid returning real data when Swagger generates a fake view for project list
- Avoid returning real data when Swagger generates a fake view for task list

## Testing
- `pytest` *(fails: DirectThread() got unexpected keyword arguments; Unknown formatter 'bank_account'; test_lead_conversion assert 404 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_688fc88eb8cc8321a4bfbd70a48b3853