### PR TITLE
chore: add enum name overrides

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -124,6 +124,18 @@ SPECTACULAR_SETTINGS = {
     'DESCRIPTION': 'API documentation for all Tamiti Studio backend services.',
     'VERSION': '1.0.0',
     'SERVE_INCLUDE_SCHEMA': False,
+    'ENUM_NAME_OVERRIDES': {
+        'TaskStatus': 'common.enums.TaskStatus',
+        'ProjectStatus': 'common.enums.ProjectStatus',
+        'PostStatus': 'common.enums.PostStatus',
+        'PartyType': 'common.enums.PartyType',
+        'AccountType': 'common.enums.AccountType',
+        'TransactionType': 'common.enums.TransactionType',
+        'ChannelType': 'common.enums.ChannelType',
+        'FollowUpType': 'common.enums.FollowUpType',
+        'ProjectRole': 'common.enums.ProjectRole',
+        'UserRole': 'users.models.User.Role',
+    },
 }
 
 SIMPLE_JWT = {


### PR DESCRIPTION
## Summary
- ensure drf-spectacular generates unique enum names for duplicated fields

## Testing
- `pytest -q` *(fails: DirectThread() got unexpected keyword arguments; Missing faker bank_account; Lead conversion endpoint 404)*
- `python manage.py spectacular --format openapi-json --file schema.json`


------
https://chatgpt.com/codex/tasks/task_e_688fc8a884948321916209274939aa9a