### PR TITLE
Add serializer and schema annotation for task toggle

### DIFF
--- a/tasks/serializers.py
+++ b/tasks/serializers.py
@@ -37,3 +37,9 @@ class TaskUpdateSerializer(serializers.ModelSerializer):
             'estimated_hours', 'actual_hours', 'assigned_to',
          'tags', 'notes', 'milestone', 'dependencies'
         )
+
+
+class TaskToggleSerializer(serializers.Serializer):
+    task = TaskSerializer(read_only=True)
+    message = serializers.CharField(read_only=True)
+

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -3,12 +3,13 @@ from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import generics, permissions, status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.response import Response
+from drf_spectacular.utils import extend_schema
 
 from tasks.filters import TaskFilter
 from tasks.models import Task
 from tasks.serializers import (
     TaskSerializer, TaskCreateSerializer, TaskUpdateSerializer,
-    TaskGroupSerializer
+    TaskGroupSerializer, TaskToggleSerializer
 )
 
 
@@ -42,6 +43,7 @@ class TaskDetailView(generics.RetrieveUpdateDestroyAPIView):
         return Task.objects.filter(project__created_by=self.request.user)
 
 
+@extend_schema(response=TaskToggleSerializer)
 @api_view(['POST'])
 @permission_classes([permissions.IsAuthenticated])
 def toggle_task_completion(request, task_id):


### PR DESCRIPTION
## Summary
- define `TaskToggleSerializer` for task toggle responses
- document `toggle_task_completion` with `extend_schema`

## Testing
- `pytest tests/test_projects.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688fc8a25cb08321ac5a51a8723dfb18